### PR TITLE
Resolves @NF-70337,

### DIFF
--- a/appdome_api.sh
+++ b/appdome_api.sh
@@ -10,7 +10,7 @@ source ./appdome_api_bash/auto_dev_sign.sh
 source ./appdome_api_bash/download.sh
 source ./appdome_api_bash/status.sh
 source ./appdome_api_bash/crashlytics.sh
-
+source ./appdome_api_bash/datadog.sh
 
 SERVER_URL="${APPDOME_SERVER_BASE_URL:-https://fusion.appdome.com}"
 API_KEY="${API_KEY_ENV:-}"
@@ -75,8 +75,17 @@ main() {
   fi
 
   if statusForObfuscation && [[ -n "$DEOBFUSCATION_SCRIPT_OUTPUT_LOCATION" ]]; then
-    download_deobfuscation_script 
-    upload_deobfuscation_mapping_to_crashlytics   
+    download_deobfuscation_script
+
+    # Check for Crashlytics API key before calling upload function
+    if [[ -n "$APP_ID" ]]; then
+        upload_deobfuscation_mapping_to_crashlytics
+    fi
+    # Check for DataDog API key before calling upload function
+    if [[ -n "$DD_API_KEY" ]]; then
+        upload_deobfuscation_mapping_to_datadog
+    fi
+
   fi
 
   if [[ -n "$SECOND_OUTPUT_FILE" ]]; then

--- a/appdome_api_bash/crashlytics.sh
+++ b/appdome_api_bash/crashlytics.sh
@@ -24,4 +24,6 @@ upload_deobfuscation_mapping_to_crashlytics() {
     if [[ $skip == false ]]; then
         firebase crashlytics:mappingfile:upload --app=$APP_ID --resource-file=com_google_firebase_crashlytics_mappingfileid.xml mapping.txt
     fi
+
+    rm -rf deobfuscation_mapping_files
 }

--- a/appdome_api_bash/datadog.sh
+++ b/appdome_api_bash/datadog.sh
@@ -1,0 +1,111 @@
+#!/bin/bash
+
+# Static boundary for multipart-encoded data
+boundary="6bd84d1042f94cc7baf9ca62779f64d7"
+# DataDog Site
+DD_SITE="datadoghq.com"
+# Create the multipart message for event JSON and mapping file
+create_multipart_message() {
+    local boundary=$1
+    local event_data=$2
+    local mapping_file_path=$3
+
+    # Start with event JSON
+    echo "--$boundary"
+    echo 'Content-Disposition: form-data; name="event"; filename="event.json"'
+    echo 'Content-Type: application/json; charset=utf-8'
+    echo
+    echo "$event_data"
+
+    # Now the mapping file
+    echo "--$boundary"
+    echo 'Content-Disposition: form-data; name="jvm_mapping_file"; filename="jvm_mapping"'
+    echo 'Content-Type: text/plain'
+    echo
+    cat "$mapping_file_path"  # Embed file content here
+
+    # Closing boundary
+    echo "--$boundary--"
+}
+upload_deobfuscation_mapping_to_datadog() {
+    skip=false
+
+    if [[ -z $DD_API_KEY ]]; then
+        echo "WARNING: Missing DataDog API key. Skipping code deobfuscation mapping file upload to DataDog."
+        skip=true
+    fi
+
+    # Unzip deobfuscation script output
+    unzip "$DEOBFUSCATION_SCRIPT_OUTPUT_LOCATION" -d deobfuscation_mapping_files
+
+    # Remove any __MACOSX files and unnecessary directory layers if they exist
+    find deobfuscation_mapping_files -name "__MACOSX" -exec rm -rf {} +
+    mv deobfuscation_mapping_files/*/* deobfuscation_mapping_files/ 2>/dev/null
+
+    if ! cd deobfuscation_mapping_files; then
+        echo "WARNING: Could not access deobfuscation_mapping_files directory. Skipping upload to DataDog."
+        skip=true
+    fi
+
+    # Check for required files
+    if [[ ! -f mapping.txt ]]; then
+        echo "WARNING: Missing mapping.txt file. Skipping code deobfuscation mapping file upload to DataDog."
+        skip=true
+    fi
+
+    if [[ ! -f data_dog_metadata.json ]]; then
+        echo "WARNING: Missing data_dog_metadata.json file. Skipping code deobfuscation mapping file upload to DataDog."
+        skip=true
+    fi
+
+      # Proceed with the upload only if skip is false
+    if [[ $skip == false ]]; then
+        # Read metadata from data_dog_metadata.json
+        build_id=$(jq -r '.build_id' data_dog_metadata.json)
+        service_name=$(jq -r '.service_name' data_dog_metadata.json)
+        version=$(jq -r '.version' data_dog_metadata.json)
+
+        if [[ -z $build_id || -z $service_name || -z $version ]]; then
+            echo "ERROR: Missing required metadata (build_id, service_name, or version) in data_dog_metadata.json."
+            cd ..
+            rm -rf deobfuscation_mapping_files
+            return
+        fi
+        # Prepare JSON payload
+        event_json=$(cat <<EOF
+{
+    "build_id": "$build_id",
+    "service": "$service_name",
+    "type": "jvm_mapping_file",
+    "version": "$version"
+}
+EOF
+        )
+
+        # Generate the multipart message body
+        multipart_message=$(create_multipart_message "$boundary" "$event_json" "mapping.txt")
+
+        # Set the DataDog API URL
+        url="https://sourcemap-intake.datadoghq.com/api/v2/srcmap"
+
+        # Send the request with curl
+        response=$(curl -w "%{http_code}" -o /dev/null -X POST "$url" \
+            -H "Content-Type: multipart/form-data; boundary=$boundary" \
+            -H "Accept-Encoding: gzip" \
+            -H "dd-evp-origin: dd-sdk-android-gradle-plugin" \
+            -H "dd-evp-origin-version: 1.13.0" \
+            -H "dd-api-key: $DD_API_KEY" \
+            --data-binary "$multipart_message")
+
+        # Check response status
+        if [[ $response -eq 202 ]]; then
+            echo "Mapping file uploaded successfully to DataDog!"
+        else
+            echo "Failed to upload mapping file to DataDog. Status code: $response"
+        fi
+    fi
+
+    # Cleanup
+    cd ..
+    rm -rf deobfuscation_mapping_files
+}

--- a/appdome_api_bash/parser.sh
+++ b/appdome_api_bash/parser.sh
@@ -89,6 +89,7 @@ help() {
   echo "-cj   |  --certificate_json                 Output file for Certified Secure json (optional)"
   echo "-dso  |  --deobfuscation_script_output      Output file deobfuscation scripts when building with "Obfuscate App Logic" (optional)"
   echo "-aid  |  --app_id                           App ID in Firebase project (optional)"
+  echo "-dd_api_key | --datadog_api_key             Data Dog API_KEY (required for DataDog Deobfuscation) (optional)"
   echo "-bv   |  --build_overrides                  Path to json file with build overrides (optional)"
   echo "-bl   |  --build_logs                       Build with diagnostic logs (optional)"
   echo "-cv   |  --context_overrides                Path to json file with context overrides (optional)"
@@ -179,6 +180,10 @@ parse_args() {
       ;;
     -aid | --app_id)
       APP_ID=$2
+      shift 2
+      ;;
+    -dd_api_key | --datadog_api_key)
+      DD_API_KEY=$2
       shift 2
       ;;
     -bv | --build_overrides)


### PR DESCRIPTION
Resolution Description:Added Support for Datadog uploading deobfuscation mapping file. Required inputs for this feature: -dd_api_key | --datadog_api_key + DEOBFUSCATION_SCRIPT_OUTPUT_LOCATION (the same as crashlytics)
* Added cleanup of deobfuscation_mapping_files in crashlytics.sh