### PR TITLE
Add SDK Protect deobfuscation mapping download support

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,6 +61,7 @@ When required arguments are missing, the script reports each one with the flag n
 --app <aar> \
 --output <output aar> \
 --certificate_output <output certificate pdf> \
+--deobfuscation_script_output <file path for downloading deobfuscation zip file> \
 --build_overrides <json_file_path> 
 ```
 
@@ -97,6 +98,7 @@ When required arguments are missing, the script reports each one with the flag n
 --keystore_pass <p12 password> \ # only needed for sign on Appdome
 --output <output zip> \
 --certificate_output <output certificate pdf> \
+--deobfuscation_script_output <file path for downloading deobfuscation zip file> \
 --build_overrides <json_file_path> 
 ```
 

--- a/appdome_api_bash/parser_sdk.sh
+++ b/appdome_api_bash/parser_sdk.sh
@@ -43,6 +43,7 @@ help() {
   echo "-o    |  --output                           Output file for fused and signed SDK after Appdome (required)"
   echo "-co   |  --certificate_output               Output file for Certified Secure pdf (optional)"
   echo "-cj   |  --certificate_json                 Output file for Certified Secure json (optional)"
+  echo "-dso  |  --deobfuscation_script_output      Output file deobfuscation scripts when building with obfuscation (optional)"
   echo "-bv   |  --build_overrides                  Path to json file with build overrides (optional)"
   echo "-bl   |  --build_logs                       Build with diagnostic logs (optional)"
   echo "-wol  |  --workflow_output_logs             Enter path to a workflow output logs file (optional)"
@@ -95,6 +96,10 @@ parse_args() {
       ;;
     -cj | --certificate_json)
       CERTIFICATE_JSON_OUTPUT_LOCATION=$2
+      shift 2
+      ;;
+    -dso | --deobfuscation_script_output)
+      DEOBFUSCATION_SCRIPT_OUTPUT_LOCATION=$2
       shift 2
       ;;
     -bv | --build_overrides)

--- a/appdome_api_sdk.sh
+++ b/appdome_api_sdk.sh
@@ -54,6 +54,10 @@ main() {
     download_certified_secure_json_test
   fi
 
+  if statusForObfuscation && [[ -n "$DEOBFUSCATION_SCRIPT_OUTPUT_LOCATION" ]]; then
+    download_deobfuscation_script
+  fi
+
   printTime $((($(date +%s) - start_all_process_time))) "Appdome API took: "
 }
 


### PR DESCRIPTION
Adds support for downloading SDK Protect deobfuscation mapping files from the SDK bash wrapper.

  Changes:
  - Adds `--deobfuscation_script_output` / `-dso` to SDK argument parsing.
  - Calls the existing deobfuscation mapping download flow when `obfuscationMapExists` is true.
  - Updates SDK README examples with the new output option.

  Validation:
  - Ran `bash -n appdome_api_sdk.sh`
  - Ran `bash -n appdome_api_bash/parser_sdk.sh`
  - Verified `./appdome_api_sdk.sh --help` includes the new option.
